### PR TITLE
A: make `autoplay` available for YT mobile

### DIFF
--- a/manifest_v2/js/autoplay+loop.js
+++ b/manifest_v2/js/autoplay+loop.js
@@ -170,8 +170,10 @@ let YTNonstop = function YTNonstop(options) {
             }, 1000),
             
             setError: function() {
-                const message = document.querySelector('#player yt-playability-error-supported-renderers[hidden]')
+                const message = document.querySelector('#player yt-playability-error-supported-renderers[hidden]') 
+				|| document.querySelector('ytm-watch ytm-player-error-message-renderer')
                 const button = document.querySelector('#player #info[class*="player-error-message"] #buttons[class*="error-message"] button[aria-label]')
+				|| document.querySelector('ytm-watch ytm-player-error-message-renderer ytm-button-renderer button[aria-label]')
 
                 if (Nonstop.getIsAutoClick() == false && get_YT.loop.button() && Nonstop.getIsAutoLoop() == true && button && !message) {
                     button.click();

--- a/manifest_v2/js/autoplay+loop.js
+++ b/manifest_v2/js/autoplay+loop.js
@@ -184,8 +184,10 @@ let YTNonstop = function YTNonstop(options) {
             setAutonav: function() {
                 const on = document.querySelector('.ytp-autonav-toggle-button-container > .ytp-autonav-toggle-button[aria-checked="true"]') 
                             || document.querySelector('#automix[role="button"][aria-pressed="true"]')
+			    || document.querySelector(button.ytm-autonav-toggle-button-container[aria-pressed="true"])
                 const off = document.querySelector('.ytp-autonav-toggle-button-container > .ytp-autonav-toggle-button[aria-checked="false"]') 
                             || document.querySelector('#automix[role="button"][aria-pressed="false"]')
+			    || document.querySelector(button.ytm-autonav-toggle-button-container[aria-pressed="false"])
         
                 if (Nonstop.getIsAutoSkip() == true && off) {
                     off.click();

--- a/manifest_v2/js/autoplay+loop.js
+++ b/manifest_v2/js/autoplay+loop.js
@@ -132,7 +132,7 @@ let YTNonstop = function YTNonstop(options) {
 //    };
     function Run() {
         const Play_Pause = {
-            getButton:window.document.getElementsByClassName("ytp-play-button ytp-button")[0] || window.document.getElementById("play-pause-button"),
+            getButton:window.document.getElementsByClassName("ytp-play-button ytp-button")[0] || window.document.getElementById("play-pause-button") || window.document.getElementsByClassName('player-control-play-pause-icon')[0],
             config: {
                 attributes:true,
                 childList:true,

--- a/manifest_v3/js/autoplay+loop.js
+++ b/manifest_v3/js/autoplay+loop.js
@@ -183,8 +183,10 @@ let YTNonstop = function YTNonstop(options) {
             setAutonav: function() {
                 const on = document.querySelector('.ytp-autonav-toggle-button-container > .ytp-autonav-toggle-button[aria-checked="true"]') 
                             || document.querySelector('#automix[role="button"][aria-pressed="true"]')
+			    || document.querySelector(button.ytm-autonav-toggle-button-container[aria-pressed="true"])
                 const off = document.querySelector('.ytp-autonav-toggle-button-container > .ytp-autonav-toggle-button[aria-checked="false"]') 
                             || document.querySelector('#automix[role="button"][aria-pressed="false"]')
+			    || document.querySelector(button.ytm-autonav-toggle-button-container[aria-pressed="false"])
         
                 if (Nonstop.getIsAutoSkip() == true && off) {
                     off.click();

--- a/manifest_v3/js/autoplay+loop.js
+++ b/manifest_v3/js/autoplay+loop.js
@@ -133,7 +133,7 @@ let YTNonstop = function YTNonstop(options) {
 //    };
     function Run() {
         const Play_Pause = {
-            getButton:window.document.getElementsByClassName("ytp-play-button ytp-button")[0] || window.document.getElementById("play-pause-button"),
+            getButton:window.document.getElementsByClassName("ytp-play-button ytp-button")[0] || window.document.getElementById("play-pause-button") || window.document.getElementsByClassName('player-control-play-pause-icon')[0],
             config: {
                 attributes:true,
                 childList:true,

--- a/manifest_v3/js/autoplay+loop.js
+++ b/manifest_v3/js/autoplay+loop.js
@@ -170,8 +170,10 @@ let YTNonstop = function YTNonstop(options) {
             }, 1000),
 
             setError: function() {
-                const message = document.querySelector('#player yt-playability-error-supported-renderers[hidden]')
-                const button = document.querySelector('#player #info[class*="player-error-message"] #buttons[class*="error-message"] button[aria-label]')
+                const message = document.querySelector('#player yt-playability-error-supported-renderers[hidden]') 
+				|| document.querySelector('ytm-watch ytm-player-error-message-renderer')
+                const button = document.querySelector('#player #info[class*="player-error-message"] #buttons[class*="error-message"] button[aria-label]') 
+				|| document.querySelector('ytm-watch ytm-player-error-message-renderer ytm-button-renderer button[aria-label]')
                 
                 if (Nonstop.getIsAutoClick() == false && get_YT.loop.button() && Nonstop.getIsAutoLoop() == true && button && !message) {
                     button.click();


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

> Any additions, changes or removals is at the Authors discretion.  
> You're free to counterargue (to a certain point) if you disagree with the decision.  
> To avoid being banned, don't constantly re-open or create new (related) issue reports or pull requests.  
### Prerequisites
<!-- Check the appropriate boxes before you submit your issue -->
- [x] I've read the [Code of Conduct](https://github.com/JohnyP36/YT-Nonstop/blob/main/.github/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/JohnyP36/YT-Nonstop/blob/main/.github/CONTRIBUTING.md)
- [x] This is more than one or two issue(s)
    - Otherwise open a [new issue](https://github.com/JohnyP36/YT-Nonstop/issues/new/choose)
- [x] I performed a cursory search of the issue tracker to avoid opening a duplicate issue
    - Your issue may already be reported.
- [x] I tried to reproduce the issue when...
    - [x] Other webextensions related to Youtube are disabled <!-- Just to ensure there is no issues or conflicts with other webbrowser extensions. -->
    - [x] using a new, unmodified browser profile
- [x] I am running the latest version of the extension

### Describe the issue
<!-- [Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.] --> 
<!-- Just a description of the issue when you visit the site. Or steps on reproducing this  -->

Although this extensions should also work on YouTube Music it does not work on dis-/enabling `autoplay`

#### Screenshot(s)
<!-- [Screenshot(s) for difficult to describe visual issues are **mandatory**. Post links instead of **Inline Images** for Screenshots containing **Adult material**.] -->
<details>
<summary>Screenshot(s)</summary>
    
</details>

### Browser & Extension version
<!-- delete the "e.g." and put between the "**...**" or "_**...**_ your own information. Change the number of your browser version if it's not 92 --> 
| Browser name & version | Extension Version | Operating System |
| :---                   |       :---:       |             ---: |
| \`e.g. **Firefox** 113\`   | \`e.g. _**2.0.6.2**_\`| \`e.g. **Windows 10**, 22H2\` | 

#### Notes
<!-- [Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.] -->
<!-- If you have a screenshot of the issue or advert, this will help to highlight it. -->
