### PR TITLE
C: loop button element

### DIFF
--- a/manifest_v2/js/autoplay+loop.js
+++ b/manifest_v2/js/autoplay+loop.js
@@ -201,14 +201,14 @@ let YTNonstop = function YTNonstop(options) {
             
             setLoop: function() {
                 const on = document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer #button[aria-label] > yt-icon path[d^="M20,"]')
-			|| document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M20,"]')
+			|| document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M20"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="Alle"]') //path[d^="M3"] is now M21
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="all"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="Tout"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="todo"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="tudo"]')
                 const off = document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer #button[aria-label] > yt-icon path[d^="M21,"]')
-			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M21,"]')
+			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M21"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="uit"]') //path[d^="M3"] is now M21
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="off"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="aus"]')
@@ -218,9 +218,9 @@ let YTNonstop = function YTNonstop(options) {
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="Desativar"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="desativada"]')
                 const o1f = document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer #button[aria-label] > yt-icon path[d^="M13,"]')
-			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M13,"]')
-                             || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M4"]')
-                           || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M13"]')
+			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M13"]')
+                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M4"]')
+                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M13"]')
                
                 if (get_YT.loop.button() && Nonstop.getIsAutoLoop() == true && off) {
                     get_YT.loop.button().click();

--- a/manifest_v3/js/autoplay+loop.js
+++ b/manifest_v3/js/autoplay+loop.js
@@ -200,14 +200,14 @@ let YTNonstop = function YTNonstop(options) {
             
             setLoop: function() {
                 const on = document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer #button[aria-label] > yt-icon path[d^="M20,"]')
-			|| document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M20,"]')
+			|| document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M20"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="Alle"]') //path[d^="M3"] is now M21
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="all"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="Tout"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="todo"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="tudo"]')
                 const off = document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer #button[aria-label] > yt-icon path[d^="M21,"]')
-			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M21,"]')
+			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M21"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="uit"]') //path[d^="M3"] is now M21
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="off"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="aus"]')
@@ -217,9 +217,9 @@ let YTNonstop = function YTNonstop(options) {
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="Desativar"]')
                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"][title*="desativada"]')
                 const o1f = document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer #button[aria-label] > yt-icon path[d^="M13,"]')
-			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M13,"]')
-                             || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M4"]')
-                           || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M13"]')
+			 || document.querySelector('#playlist-action-menu ytd-playlist-loop-button-renderer button[aria-label] yt-icon path[d^="M13"]')
+                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M4"]')
+                            || document.querySelector('ytmusic-player-bar > #right-controls > div[class^="right-controls-buttons"] > [class^="repeat"] path[d^="M13"]')
                
                 if (get_YT.loop.button() && Nonstop.getIsAutoLoop() == true && off) {
                     get_YT.loop.button().click();


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

> Any additions, changes or removals is at the Authors discretion.  
> You're free to counterargue (to a certain point) if you disagree with the decision.  
> To avoid being banned, don't constantly re-open or create new (related) issue reports or pull requests.  
### Prerequisites
<!-- Check the appropriate boxes before you submit your issue -->
- [x] I've read the [Code of Conduct](https://github.com/JohnyP36/YT-Nonstop/blob/main/.github/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/JohnyP36/YT-Nonstop/blob/main/.github/CONTRIBUTING.md)
- [x] This is more than one or two issue(s)
    - Otherwise open a [new issue](https://github.com/JohnyP36/YT-Nonstop/issues/new/choose)
- [x] I performed a cursory search of the issue tracker to avoid opening a duplicate issue
    - Your issue may already be reported.
- [x] I tried to reproduce the issue when...
    - [ ] Other webextensions related to Youtube are disabled <!-- Just to ensure there is no issues or conflicts with other webbrowser extensions. -->
    - [ ] using a new, unmodified browser profile
- [x] I am running the latest version of the extension

### Describe the issue
<!-- [Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.] --> 
<!-- Just a description of the issue when you visit the site. Or steps on reproducing this  -->
Because YouTube removed the `,` in their path of the icon, I had to change it here to

#### Screenshot(s)
<!-- [Screenshot(s) for difficult to describe visual issues are **mandatory**. Post links instead of **Inline Images** for Screenshots containing **Adult material**.] -->
<details>
<summary>Screenshot(s)</summary>
    
<!-- drag-and-drop screenshot here (make sure the '<!--' before after this line are deleted) -->
    
</details>

### Browser & Extension version
<!-- delete the "e.g." and put between the "**...**" or "_**...**_ your own information. Change the number of your browser version if it's not 92 --> 
| Browser name & version | Extension Version | Operating System |
| :---                   |       :---:       |             ---: |
| \`**Firefox** 113\`   | \`_**2.0.7.2**_\`| \`**Windows 10**, 22H2\` | 

#### Notes
<!-- [Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.] -->
<!-- If you have a screenshot of the issue or advert, this will help to highlight it. -->
